### PR TITLE
Various fixes in delfi_attributes.json

### DIFF
--- a/delfi_attributes.json
+++ b/delfi_attributes.json
@@ -1085,7 +1085,7 @@
     "CONDITION": {
       "osm_tags": {
         "highway": "steps",
-        "conveying": true      
+        "conveying": true
       },
       "osm_element": "OpenWay"
     },

--- a/delfi_attributes.json
+++ b/delfi_attributes.json
@@ -247,7 +247,7 @@
       ]
     },
     "TAGS": {
-      "wheelchair": "designated"
+      "wheelchair": ["designated"]
     }
   },
   {
@@ -268,7 +268,7 @@
       ]
     },
     "TAGS": {
-      "wheelchair": "yes"
+      "wheelchair": ["yes"]
     }
   },
   {
@@ -289,7 +289,7 @@
       ]
     },
     "TAGS": {
-      "centralkey": "eurokey"
+      "centralkey": ["eurokey"]
     }
   },
   {
@@ -559,7 +559,7 @@
       }
     },
     "TAGS": {
-      "kerb:approach_aid": "yes"
+      "kerb:approach_aid": ["yes"]
     }
   },
   {

--- a/delfi_attributes.json
+++ b/delfi_attributes.json
@@ -1085,12 +1085,16 @@
     "CONDITION": {
       "osm_tags": {
         "highway": "steps",
-        "conveying": true
+        "conveying": true      
       },
       "osm_element": "OpenWay"
     },
     "TAGS": {
-      "incline": []
+      "conveying": [
+        "forward",
+        "backward",
+        "reversible"
+      ]
     }
   },
   {

--- a/delfi_attributes.json
+++ b/delfi_attributes.json
@@ -422,11 +422,27 @@
     "LABEL": "Mit akustischer Ausgabe",
     "CONDITION": {
       "osm_tags": {
+        "railway": "station",
         "departures_board": "realtime"
       }
     },
     "TAGS": {
       "departures_board:speech_output": [
+        "yes",
+        "no"
+      ]
+    }
+  },
+  {
+    "DELFI_ID": 1131,
+    "LABEL": "Mit akustischer Ausgabe",
+    "CONDITION": {
+      "osm_tags": {
+        "departures_board": "realtime"
+      }
+    },
+    "TAGS": {
+      "speech_output": [
         "yes",
         "no"
       ]


### PR DESCRIPTION
This PR:

- makes sure all values for the dictionary in TAGS are always lists, even if only one value is present
- Splits 1131 into two, so that sperately and non-seperately mapped station-wide departure boards are recognized
- Implements the best fix possible for 2131 and 2133, making sure `conveying=reversible` counts as "known direction"